### PR TITLE
Update project naming conventions with examples

### DIFF
--- a/feature_detection/docs/project_naming_conventions.md
+++ b/feature_detection/docs/project_naming_conventions.md
@@ -7,8 +7,11 @@ Ingredients:
 
 Examples:
 - `Cloud top features - overshooting top`
-- `Cloud top features - convective features`
+- `Convection - gravity waves`
+- `Convection - overshooting top`
 - `GIAD TS tracking - tropical storms`
+
+Test projects should be clearly marked with `sandbox` postfix.
 
 ## Description
 


### PR DESCRIPTION
Added examples for project naming conventions and noted the use of 'sandbox' postfix for test projects.